### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+liblastfm (1.0.9-2) UNRELEASED; urgency=medium
+
+  * Use secure URI in Vcs control header.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Mon, 15 Oct 2018 06:43:49 +0000
+
 liblastfm (1.0.9-1) unstable; urgency=low
 
   * New upstream release. (Closes: #805081)

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,9 @@ liblastfm (1.0.9-2) UNRELEASED; urgency=medium
 
   * Use secure URI in Vcs control header.
   * Trim trailing whitespace.
+  * Transition to automatic debug packages (from: liblastfm5-dbg,
+    liblastfm-fingerprint1-dbg, liblastfm-dbg, liblastfm-fingerprint5-
+    dbg).
 
  -- Jelmer Vernooĳ <jelmer@debian.org>  Mon, 15 Oct 2018 06:43:49 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -5,6 +5,7 @@ liblastfm (1.0.9-2) UNRELEASED; urgency=medium
   * Transition to automatic debug packages (from: liblastfm5-dbg,
     liblastfm-fingerprint1-dbg, liblastfm-dbg, liblastfm-fingerprint5-
     dbg).
+  * Use secure copyright file specification URI.
 
  -- Jelmer Vernooĳ <jelmer@debian.org>  Mon, 15 Oct 2018 06:43:49 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 liblastfm (1.0.9-2) UNRELEASED; urgency=medium
 
   * Use secure URI in Vcs control header.
+  * Trim trailing whitespace.
 
  -- Jelmer Vernooĳ <jelmer@debian.org>  Mon, 15 Oct 2018 06:43:49 +0000
 
@@ -14,7 +15,7 @@ liblastfm (1.0.9-1) unstable; urgency=low
   * debian/control:
     - Standards-Version: 3.9.6
   * update debian/copyright
-  * Remove patch applied upstream: 
+  * Remove patch applied upstream:
     - fix_q_os_x11.patch
   * Add patch:
     - change_target-name.patch

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Build-Depends:
 Standards-Version: 3.9.6
 Section: libs
 Homepage: http://www.last.fm/
-Vcs-Git: git://github.com/justin-time/liblastfm.git
+Vcs-Git: https://github.com/justin-time/liblastfm.git
 Vcs-Browser: https://github.com/justin-time/liblastfm
 
 Package: liblastfm-dev

--- a/debian/control
+++ b/debian/control
@@ -126,7 +126,7 @@ Description: Debugging symbols for the Last.fm web services library (Qt5 build)
  with their web services.
  .
  This package contains the debugging symbols for the liblastfm libraries.
- 
+
 Package: liblastfm-fingerprint1-dbg
 Architecture: any
 Multi-Arch: same
@@ -141,7 +141,7 @@ Description: Debugging symbols for the fingerprint library (Qt4 build)
  .
  This package contains the debugging symbols for the liblastfm-fingerprint
  libraries.
- 
+
 Package: liblastfm-fingerprint5-dbg
 Architecture: any
 Multi-Arch: same

--- a/debian/control
+++ b/debian/control
@@ -1,14 +1,7 @@
 Source: liblastfm
 Priority: optional
 Maintainer: Stefan Ahlers <stef.ahlers@t-online.de>
-Build-Depends:
- cmake,
- debhelper (>= 9),
- libfftw3-dev,
- libqt4-dev,
- qtbase5-dev,
- libsamplerate0-dev,
- pkg-kde-tools
+Build-Depends: cmake, debhelper (>= 9.20160114), libfftw3-dev, libqt4-dev, qtbase5-dev, libsamplerate0-dev, pkg-kde-tools
 Standards-Version: 3.9.6
 Section: libs
 Homepage: http://www.last.fm/
@@ -58,21 +51,6 @@ Description: Last.fm fingerprinting library (Qt4 build)
  This library lets you fingerprint decoded audio tracks and fetch metadata
  suggestions for them.
 
-Package: liblastfm-dbg
-Architecture: any
-Multi-Arch: same
-Section: debug
-Priority: extra
-Depends:
- liblastfm-fingerprint1 (= ${binary:Version}),
- liblastfm1 (= ${binary:Version}),
- ${misc:Depends}
-Description: Debugging symbols for the Last.fm web services library (Qt4 build)
- liblastfm is a collection of C++/Qt4 libraries provided by Last.fm for use
- with their web services.
- .
- This package contains the debugging symbols for the liblastfm libraries.
-
 Package: liblastfm-fingerprint5-1
 Architecture: any
 Multi-Arch: same
@@ -112,47 +90,3 @@ Description: Last.fm web services library (Qt5 build)
  with their web services.
  .
  This package contains the base web services library.
-
-Package: liblastfm5-dbg
-Architecture: any
-Multi-Arch: same
-Section: debug
-Priority: extra
-Depends:
- liblastfm5-1 (= ${binary:Version}),
- ${misc:Depends}
-Description: Debugging symbols for the Last.fm web services library (Qt5 build)
- liblastfm is a collection of C++/Qt5 libraries provided by Last.fm for use
- with their web services.
- .
- This package contains the debugging symbols for the liblastfm libraries.
-
-Package: liblastfm-fingerprint1-dbg
-Architecture: any
-Multi-Arch: same
-Section: debug
-Priority: extra
-Depends:
- liblastfm5-1 (= ${binary:Version}),
- ${misc:Depends}
-Description: Debugging symbols for the fingerprint library (Qt4 build)
- liblastfm is a collection of C++/Qt4 libraries provided by Last.fm for use
- with their web services.
- .
- This package contains the debugging symbols for the liblastfm-fingerprint
- libraries.
-
-Package: liblastfm-fingerprint5-dbg
-Architecture: any
-Multi-Arch: same
-Section: debug
-Priority: extra
-Depends:
- liblastfm5-1 (= ${binary:Version}),
- ${misc:Depends}
-Description: Debugging symbols for the fingerprint library (Qt5 build)
- liblastfm is a collection of C++/Qt5 libraries provided by Last.fm for use
- with their web services.
- .
- This package contains the debugging symbols for the liblastfm-fingerprint
- libraries.

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,4 +1,4 @@
-Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: liblastfm
 Upstream-Contact: Michael Coffey <michaelc@last.fm>
 Source: https://github.com/lastfm/liblastfm

--- a/debian/rules
+++ b/debian/rules
@@ -40,10 +40,10 @@ override_dh_auto_install:
 	dh_auto_install -B$(QT5_PATH)
 
 override_dh_strip:
-	dh_strip -pliblastfm1 --dbg-package=liblastfm-dbg
-	dh_strip -pliblastfm5-1 --dbg-package=liblastfm5-dbg
-	dh_strip -pliblastfm-fingerprint1 --dbg-package=liblastfm-fingerprint1-dbg
-	dh_strip -pliblastfm-fingerprint5-1 --dbg-package=liblastfm-fingerprint5-dbg
+	dh_strip -pliblastfm1 --dbgsym-migration='liblastfm-dbg (<< 1.0.9-2)'
+	dh_strip -pliblastfm5-1 --dbgsym-migration='liblastfm5-dbg (<< 1.0.9-2)'
+	dh_strip -pliblastfm-fingerprint1 --dbgsym-migration='liblastfm-fingerprint1-dbg (<< 1.0.9-2)'
+	dh_strip -pliblastfm-fingerprint5-1 --dbgsym-migration='liblastfm-fingerprint5-dbg (<< 1.0.9-2)'
 
 override_dh_install:
 	dh_install --list-missing


### PR DESCRIPTION
Fix some issues reported by lintian
* Use secure URI in Vcs control header.
* Trim trailing whitespace.
* Transition to automatic debug packages (from: liblastfm5-dbg, liblastfm-fingerprint1-dbg, liblastfm-dbg, liblastfm-fingerprint5-dbg).
* Use secure copyright file specification URI.
